### PR TITLE
修正 url_check.py 的不完備 logging、移除 deadcode 及重新格式化

### DIFF
--- a/url_check.py
+++ b/url_check.py
@@ -27,7 +27,6 @@ import asyncio
 import configparser
 from enum import Enum
 from typing import Any, Iterable, Tuple, TypedDict, cast
-import aiofiles
 import aiohttp
 from loguru import logger
 
@@ -44,17 +43,6 @@ class SubscribedUrl(TypedDict):
     blogname: str  # ex. MozTW YouTube
     icon: str  # ex. default
     truelink: str  # ex. https://www.youtube.com/moztw
-
-async def read_config_as_string() -> str:
-    '''讀入 config.ini 並回傳其內容。'''
-    config_raw: str | None = None
-
-    logger.info("開始讀取 config.ini⋯⋯")
-    async with aiofiles.open('moztw/config.ini', 'r', encoding='utf-8') as f:
-        config_raw = await f.read()
-
-    assert config_raw != None and len(config_raw) > 0, "config_raw 應有資料。"
-    return config_raw
 
 def extract_urls_from_config(config: dict[str, Any]) -> dict[str, SubscribedUrl]:
     '''只留下來 key 是 ``http`` 開頭的資料（我們只打算處理網址）。

--- a/url_check.py
+++ b/url_check.py
@@ -87,13 +87,13 @@ async def try_request(url: str) -> Tuple[SiteStatus, str | None]:
                     else:
                         # 反之，認定為普通的存取。
                         return (SiteStatus.Normal, None)
+                else:
+                    logger.error(f"無法存取 {url}，因為網站回傳了錯誤代碼 {resp.status}。")
 
         except aiohttp.ClientResponseError as cre:
-            logger.error(f"無法連線至 {cre.request_info.url}，錯誤代碼是 {cre.code}。")
+            logger.error(f"無法連線至 {cre.request_info.url}，錯誤訊息是 {cre.message}。")
 
-            # 連不上就當壞掉的。
-            return (SiteStatus.Unavailable, None)
-
+    # 沒有 early return 都是壞的。
     return (SiteStatus.Unavailable, None)
 
 def interpret_result(url: str, response: Tuple[SiteStatus, str | None]) -> str | None:

--- a/url_check.requirements.txt
+++ b/url_check.requirements.txt
@@ -1,4 +1,3 @@
-aiofiles==0.8.0
 aiohttp==3.8.1
 aiosignal==1.2.0
 async-timeout==4.0.2


### PR DESCRIPTION
原先的 `try-except` 沒涵蓋到伺服器端回傳 4xx（或 5xx）的情形。本 PR 補上相關的 log，並合併重複的 `return (SiteStatus.Unavailable, None)`。